### PR TITLE
fix: use correct tokenizer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 -f https://download.pytorch.org/whl/torch_stable.html
 torch==1.9.0+cpu
 transformers==4.9.1
+ftfy==6.0.3
+spacy==3.2.1


### PR DESCRIPTION
We get the following warning:
ftfy or spacy is not installed using BERT BasicTokenizer instead of ftfy.